### PR TITLE
Fix import statement in fontawesome documentation

### DIFF
--- a/docs/assets/components/views/FontAwesome.vue
+++ b/docs/assets/components/views/FontAwesome.vue
@@ -61,19 +61,15 @@
     <div class="ui segment">
         <!-- HTML generated using hilite.me -->
         <div style="background: #ffffff; overflow:auto;width:auto;;border-width:.1em .1em .1em .8em;padding:.2em .6em;"><pre style="margin: 0; line-height: 125%"><span style="color: #0000aa">import</span> {FaRating} from <span style="color: #aa5500">&#39;vue-rate-it&#39;</span>;
-<span style="color: #0000aa">import</span> {ThumbsUp} from <span style="color: #aa5500">&#39;vue-rate-it/glyphs/thumbs-up&#39;</span>;
+<span style="color: #0000aa">import</span> ThumbsUp from <span style="color: #aa5500">&#39;vue-rate-it/glyphs/thumbs-up&#39;</span>;
 
 <span style="color: #0000aa">export</span> <span style="color: #0000aa">default</span>{
   components:{
     FaRating
   },
-  created(){
-    // register the icon
-    this.thumbsUp = ThumbsUp
-  },
   data(){
     return{
-      thumbsUp: '' // declare the icon
+      thumbsUp: ThumbsUp // declare the icon
     } 
   } 
 }


### PR DESCRIPTION
Currently in [Font-Awesome documentation](https://craigh411.github.io/vue-rate-it/#/docs/font-awesome), it says

    import {ThumbsUp} from 'vue-rate-it/glyphs/thumbs-up';

But there is not ThumbsUp object in `vue-rate-it/glyphs/thumbs-up` file.

And it says

    created() {
        // register the icon
        this.thumbsUp = ThumbsUp
    },
    data() {
        return{
            thumbsUp: '' // declare the icon
        } 
    } 

But it doesn't require to set in created function. It will work just fine if we set `ThumbsUp` in data.
Like this:

    data() {
        return {
            thumbsUp: ThumbsUp // declare the icon
        } 
    } 

So this PR fixes that with simpler documentation